### PR TITLE
Joystick reset & SortingLayers

### DIFF
--- a/Assets/Prefabs/Rooms/Room.prefab
+++ b/Assets/Prefabs/Rooms/Room.prefab
@@ -106,9 +106,9 @@ TilemapRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
-  m_SortingOrder: 1
+  m_SortingLayerID: -1776034659
+  m_SortingLayer: 2
+  m_SortingOrder: 0
   m_ChunkSize: {x: 32, y: 32, z: 32}
   m_ChunkCullingBounds: {x: 0, y: 0, z: 0}
   m_MaxChunkCount: 16
@@ -382,8 +382,8 @@ TilemapRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
+  m_SortingLayerID: 1331908439
+  m_SortingLayer: 1
   m_SortingOrder: 0
   m_ChunkSize: {x: 32, y: 32, z: 32}
   m_ChunkCullingBounds: {x: 0, y: 0, z: 0}
@@ -400,6 +400,11 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 8441795155235781111}
     m_Modifications:
+    - target: {fileID: 4096000707445137261, guid: eaf9319e401c8fe48918502d611d5619,
+        type: 3}
+      propertyPath: m_Name
+      value: Teleporter
+      objectReference: {fileID: 0}
     - target: {fileID: 4096000707445137257, guid: eaf9319e401c8fe48918502d611d5619,
         type: 3}
       propertyPath: m_LocalPosition.x
@@ -455,11 +460,6 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 4096000707445137261, guid: eaf9319e401c8fe48918502d611d5619,
-        type: 3}
-      propertyPath: m_Name
-      value: Teleporter
-      objectReference: {fileID: 0}
     - target: {fileID: 4096000707445137258, guid: eaf9319e401c8fe48918502d611d5619,
         type: 3}
       propertyPath: m_SpriteTilingProperty.oldSize.x
@@ -489,4 +489,3 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 1694497402307969638}
   m_PrefabAsset: {fileID: 0}
-  

--- a/Assets/Prefabs/Teleporter.prefab
+++ b/Assets/Prefabs/Teleporter.prefab
@@ -81,9 +81,9 @@ SpriteRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
-  m_SortingOrder: 1
+  m_SortingLayerID: 1087666413
+  m_SortingLayer: 6
+  m_SortingOrder: 0
   m_Sprite: {fileID: -7323714281632682858, guid: 5b84a853619563743b56ed651748018f,
     type: 3}
   m_Color: {r: 1, g: 1, b: 1, a: 1}

--- a/Assets/Scenes/RoomScene.unity
+++ b/Assets/Scenes/RoomScene.unity
@@ -478,7 +478,7 @@ PrefabInstance:
     - target: {fileID: 2589535973013731875, guid: eb27c0afd450f634caf1b7a967882007,
         type: 3}
       propertyPath: m_SortingLayerID
-      value: 0
+      value: -1812816783
       objectReference: {fileID: 0}
     - target: {fileID: 2589535973013731875, guid: eb27c0afd450f634caf1b7a967882007,
         type: 3}
@@ -854,6 +854,7 @@ MonoBehaviour:
   PauseMenuButton: {fileID: 1765890520}
   GameOverUI: {fileID: 141353827}
   scoreNumber: {fileID: 1914475202}
+  joystick: {fileID: 2140435822}
   sceneFader: {fileID: 1418097325}
 --- !u!225 &141353830
 CanvasGroup:
@@ -3039,7 +3040,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.22, y: 0.77}
   m_AnchorMax: {x: 0.78, y: 1}
-  m_AnchoredPosition: {x: 0, y: 0.30000305}
+  m_AnchoredPosition: {x: 0, y: 0.2999878}
   m_SizeDelta: {x: 0, y: -0.6000061}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &1819371388

--- a/Assets/Scripts/Player/Player_Main.cs
+++ b/Assets/Scripts/Player/Player_Main.cs
@@ -47,8 +47,11 @@ public class Player_Main : MonoBehaviour
             HP -= enemy.GetComponent<Enemy>().strength;
         }
 
+        //kein Knockback bei GameOver
+        if(HP > 0)
+        {
         StartCoroutine(GetComponent<Player_Movement>().KnockbackCo((transform.position - enemy.transform.position), enemy.GetComponent<Enemy>().attackKnockback));
-
+        }
     }
 
     /// <summary>

--- a/Assets/Scripts/Player/Player_Movement.cs
+++ b/Assets/Scripts/Player/Player_Movement.cs
@@ -36,8 +36,21 @@ public class Player_Movement : MonoBehaviour
     // FixedUpdate wird einmal pro Frame aufgerufen und fragt jedes mal die Position des Joysticks ab. Diese Position wird dann in eine Bewegung für den Player umgerechnet.
     void FixedUpdate()
     {
+        if(!GameManager.gameOver)
+        {
         moveY = joystick.Vertical;
         moveX = joystick.Horizontal;
+        } else{
+            moveX = 0;
+            moveY = 0;
+
+            //hiermit wird das Knockback deaktiviert
+            rb.velocity = Vector2.zero;
+
+            //oder hier die Sterbeanimation einfügen
+            animator.SetFloat("speed_horizontal", moveX);
+            animator.SetFloat("speed_vertical", moveY);
+        }
 
         // Movement funktioniert nur, wenn gerade kein Knockback stattfindet
         if (isKnockback == false) {

--- a/Assets/Scripts/RoomSceneUI/GameOver.cs
+++ b/Assets/Scripts/RoomSceneUI/GameOver.cs
@@ -9,6 +9,7 @@
 using UnityEngine;
 using UnityEngine.UI;
 using UnityEngine.SceneManagement;
+using UnityEngine.EventSystems;
 
 public class GameOver : MonoBehaviour
 {
@@ -16,6 +17,7 @@ public class GameOver : MonoBehaviour
     public GameObject PauseMenuButton;
     public GameObject GameOverUI;
     public Text scoreNumber;
+    public Joystick joystick;
 
 
     public RoomFader sceneFader;
@@ -42,6 +44,9 @@ public class GameOver : MonoBehaviour
     ///<summary>
     public void GoGameOver()
     {
+        //Den Joystick loslassen => Player hört auf zu laufen
+        joystick.SendMessage("OnPointerUp", new PointerEventData(EventSystem.current));
+        
         GameManager.gameOver = true;
         PlayerUI.SetActive(!PlayerUI.activeSelf);
         PauseMenuButton.SetActive(false);

--- a/Assets/Scripts/RoomSceneUI/InventoryManager.cs
+++ b/Assets/Scripts/RoomSceneUI/InventoryManager.cs
@@ -1,6 +1,7 @@
 ﻿
 using UnityEngine;
 using UnityEngine.UI;
+using UnityEngine.EventSystems;
 
 /*
  Ersteller: Rene Jokiel
@@ -15,12 +16,19 @@ public class InventoryManager : MonoBehaviour
     public GameObject ui2;    // Zu deaktivierende ui. Nur notwendig, wenn die UIs in
                               // separaten Canvas(es?) sind
     public Text scoreNumber;
+    public Joystick joystick;
     public bool gameOver = false;
 
     public void Toggle()    // Aktiviert ui1 und deaktiviert ui2
     {
         //den Score im Pausemenü aktualisieren
         scoreNumber.text = GameManager.GetScore().ToString();
+
+        //nur beim aktivieren von ui (PauseMenu), sonst wird eine Exception geworfen
+        if(!ui.activeSelf){
+            //Den Joystick loslassen => Player hört auf zu laufen
+            joystick.SendMessage("OnPointerUp", new PointerEventData(EventSystem.current));
+        }
 
         if (gameOver == false)
         {

--- a/ProjectSettings/TagManager.asset
+++ b/ProjectSettings/TagManager.asset
@@ -45,9 +45,21 @@ TagManager:
   - name: Default
     uniqueID: 0
     locked: 0
+  - name: RoomGround
+    uniqueID: 1331908439
+    locked: 0
+  - name: RoomCollision
+    uniqueID: 2518932637
+    locked: 0
+  - name: Teleporter
+    uniqueID: 1087666413
+    locked: 0
   - name: Player
     uniqueID: 87370941
     locked: 0
   - name: Enemy
     uniqueID: 3064470775
+    locked: 0
+  - name: PlayerUI
+    uniqueID: 2482150513
     locked: 0


### PR DESCRIPTION
- Joystick will now reset (go back to 0, 0) when Game is paused or over
- All GameObjects in RoomScene (except Screen Space - Overlay Canvases) now have their correct SortingLayer (SortingLayers (order from back to front): Background (LayerName: Default), RoomCollision, RoomGround, Teleporter, Player, Enemy, PlayerUI); 
RoomGround-Layer is in front of RoomCollision-Layer because this way you will easier notice whether you have placed a Tile in the same spot in both Tilemaps (at least I hope so)